### PR TITLE
Expose and apply gravity in Jolt subsystem

### DIFF
--- a/Source/UnrealJolt/Private/JoltSubsystem.cpp
+++ b/Source/UnrealJolt/Private/JoltSubsystem.cpp
@@ -151,8 +151,8 @@ void UJoltSubsystem::SetPaused(bool bPaused)
 void UJoltSubsystem::SetGravity(const FVector& gravity)
 {
 	if (!MainPhysicsSystem) return;
-	MainPhysicsSystem->SetGravity(JPH::Vec3Arg(gravity.X / 100.f, gravity.Z / 100.f, gravity.Y / 100.f));
-
+	MainPhysicsSystem->SetGravity(JoltHelpers::ToJoltVec3(gravity));
+	
 	// We need to wake up all dynamic bodies once gravity is set
 	for (const FJoltBodyActor& JoltBodyActor : JoltBodyActors)
 	{
@@ -164,8 +164,7 @@ void UJoltSubsystem::SetGravity(const FVector& gravity)
 FVector UJoltSubsystem::GetGravity() const
 {
 	if (!MainPhysicsSystem) return FVector();
-	JPH::Vec3Arg gravityVector = MainPhysicsSystem->GetGravity();
-	return FVector(gravityVector.GetX() * 100.f, gravityVector.GetZ() * 100.f, gravityVector.GetY() * 100.f);
+	return JoltHelpers::ToUESize(MainPhysicsSystem->GetGravity());
 }
 
 // Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors
@@ -405,20 +404,8 @@ void UJoltSubsystem::InitPhysicsSystem(
 #ifdef JPH_DEBUG_RENDERER
 	JoltDebugRendererImpl = new UEJoltDebugRenderer(GetWorld());
 #endif
-	// Jolt uses Y axis as the up direction, and unreal uses the Z axis. So, set gravity for Y
-	// World should always exist for a world subsystem, but you never know.
-	if (UWorld* World = GetWorld())
-	{
-		const float GravityZ = World->GetWorldSettings()->bGlobalGravitySet ?
-			World->GetGravityZ() :
-			World->GetDefaultGravityZ();
-		
-		MainPhysicsSystem->SetGravity(JPH::Vec3Arg(0.0f, GravityZ / 100.f, 0.0f));
-	}  
-	else
-	{
-		MainPhysicsSystem->SetGravity(JPH::Vec3Arg(0.0f, -9.8f, 0.0f));
-	}
+	// Set gravity according to the default gravity vector in settings
+	MainPhysicsSystem->SetGravity(JoltHelpers::ToJoltVec3(JoltSettings->DefaultGravity));
 	MainPhysicsSystem->Init(
 		cMaxBodies,
 		cNumBodyMutexes,

--- a/Source/UnrealJolt/Private/JoltSubsystem.cpp
+++ b/Source/UnrealJolt/Private/JoltSubsystem.cpp
@@ -148,6 +148,26 @@ void UJoltSubsystem::SetPaused(bool bPaused)
 	}
 }
 
+void UJoltSubsystem::SetGravity(const FVector& gravity)
+{
+	if (!MainPhysicsSystem) return;
+	MainPhysicsSystem->SetGravity(JPH::Vec3Arg(gravity.X / 100.f, gravity.Z / 100.f, gravity.Y / 100.f));
+
+	// We need to wake up all dynamic bodies once gravity is set
+	for (const FJoltBodyActor& JoltBodyActor : JoltBodyActors)
+	{
+		if (GetBodyInterface()->GetMotionType(*JoltBodyActor.JoltBodyID) == JPH::EMotionType::Dynamic)
+			GetBodyInterface()->ActivateBody(*JoltBodyActor.JoltBodyID);
+	}
+}
+
+FVector UJoltSubsystem::GetGravity() const
+{
+	if (!MainPhysicsSystem) return FVector();
+	JPH::Vec3Arg gravityVector = MainPhysicsSystem->GetGravity();
+	return FVector(gravityVector.GetX() * 100.f, gravityVector.GetZ() * 100.f, gravityVector.GetY() * 100.f);
+}
+
 // Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors
 void UJoltSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 {
@@ -386,7 +406,19 @@ void UJoltSubsystem::InitPhysicsSystem(
 	JoltDebugRendererImpl = new UEJoltDebugRenderer(GetWorld());
 #endif
 	// Jolt uses Y axis as the up direction, and unreal uses the Z axis. So, set gravity for Y
-	MainPhysicsSystem->SetGravity(JPH::Vec3Arg(0.0f, -9.8f, 0.0f));
+	// World should always exist for a world subsystem, but you never know.
+	if (UWorld* World = GetWorld())
+	{
+		const float GravityZ = World->GetWorldSettings()->bGlobalGravitySet ?
+			World->GetGravityZ() :
+			World->GetDefaultGravityZ();
+		
+		MainPhysicsSystem->SetGravity(JPH::Vec3Arg(0.0f, GravityZ / 100.f, 0.0f));
+	}  
+	else
+	{
+		MainPhysicsSystem->SetGravity(JPH::Vec3Arg(0.0f, -9.8f, 0.0f));
+	}
 	MainPhysicsSystem->Init(
 		cMaxBodies,
 		cNumBodyMutexes,

--- a/Source/UnrealJolt/Public/JoltSettings.h
+++ b/Source/UnrealJolt/Public/JoltSettings.h
@@ -139,6 +139,12 @@ public:
 	 */
 	UPROPERTY(Config, EditAnywhere, Category = Settings)
 	int TickRate;
+	
+	/*
+	 * Default gravity in Unreal units. Can be overridden by SetGravity. 
+	 */
+	UPROPERTY(Config, EditAnywhere, Category = Settings)
+	FVector DefaultGravity = FVector(0.f, 0.f, -980.f);
 
 	/*
 	 * We need a temp allocator for temporary allocations during the physics update. We're

--- a/Source/UnrealJolt/Public/JoltSubsystem.h
+++ b/Source/UnrealJolt/Public/JoltSubsystem.h
@@ -216,6 +216,12 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Jolt Physics")
 	bool IsPaused() const { return bStepPaused; }
+	
+	UFUNCTION(BlueprintCallable, Category = "Jolt Physics")
+	void SetGravity(const FVector& gravity);
+
+	UFUNCTION(BlueprintCallable, Category = "Jolt Physics")
+	FVector GetGravity() const;
 
 	UFUNCTION(BlueprintCallable, Category = "Jolt Physics")
 	bool GetContactInfo(FContactInfo& contactInfo) const { return ContactListener->Consume(contactInfo); };


### PR DESCRIPTION
Add Blueprint-callable SetGravity and GetGravity to UJoltSubsystem. InitPhysicsSystem now reads World gravity (or default if unoverrided) and sets Jolt gravity with proper axis mapping (Unreal Z to Jolt Y) and unit conversion (cm to m). SetGravity wakes dynamic bodies after changing gravity. A fallback of -9.8 m/s is used if no world is available (somehow).

<img width="252" height="290" alt="image" src="https://github.com/user-attachments/assets/976994df-5f2f-486b-abcd-2b0e6fc9d33c" />
