### PR TITLE
Add physics callback interface

### DIFF
--- a/Source/UnrealJolt/Private/JoltSubsystem.cpp
+++ b/Source/UnrealJolt/Private/JoltSubsystem.cpp
@@ -136,10 +136,15 @@ void UJoltSubsystem::AddPostInterpolationCallback(const TDelegate<void(float)>& 
 
 void UJoltSubsystem::RegisterPhysicsListener(AActor* Listener)
 {
+	if (!Listener)
+	{
+		UE_LOG(JoltSubSystemLogs, Warning, TEXT("RegisterPhysicsListener: Listener is invalid"))
+		return;
+	}
+
 	if (Listener->Implements<UJoltPhysicsCallbackInterface>())
 	{
-		const TScriptInterface<IJoltPhysicsCallbackInterface> Interface = Listener;
-		PhysicsListeners.AddUnique(Interface);
+		PhysicsListeners.AddUnique(TWeakObjectPtr<UObject>(Listener));
 	}
 	else
 	{
@@ -149,36 +154,48 @@ void UJoltSubsystem::RegisterPhysicsListener(AActor* Listener)
 
 void UJoltSubsystem::UnregisterPhysicsListener(AActor* Listener)
 {
-	if (Listener->Implements<UJoltPhysicsCallbackInterface>())
-	{
-		const TScriptInterface<IJoltPhysicsCallbackInterface> Interface = Listener;
-		PhysicsListeners.Remove(Interface);
-	}
-	else
-	{
-		UE_LOG(JoltSubSystemLogs, Warning, TEXT("UnregisterPhysicsListener: %s does not implement IJoltPhysicsCallbackInterface"), *Listener->GetName());
-	}
+    if (!Listener)
+    {
+        UE_LOG(JoltSubSystemLogs, Warning, TEXT("UnregisterPhysicsListener: Listener is invalid"))
+        return;
+    }
+	
+    PhysicsListeners.RemoveAll([Listener](const TWeakObjectPtr<>& Entry)
+    {
+        return Entry.Get() == Listener;
+    });
 }
 
 void UJoltSubsystem::BroadcastPrePhysicsListeners(float DeltaTime)
 {
-	for (const TScriptInterface<IJoltPhysicsCallbackInterface>& Listener : PhysicsListeners)
+	for (auto It = PhysicsListeners.CreateIterator(); It; ++It)
 	{
-		if (UObject* Obj = Listener.GetObject())
+		UObject* Obj = It->Get();
+
+		// Prune invalid physics listeners
+		if (!IsValid(Obj))
 		{
-			IJoltPhysicsCallbackInterface::Execute_OnPrePhysicsStep(Obj, DeltaTime);
+			It.RemoveCurrent();
+			continue;
 		}
+
+		IJoltPhysicsCallbackInterface::Execute_OnPrePhysicsStep(Obj, DeltaTime);
 	}
 }
 
 void UJoltSubsystem::BroadcastPostPhysicsListeners(float DeltaTime)
 {
-	for (const TScriptInterface<IJoltPhysicsCallbackInterface>& Listener : PhysicsListeners)
+	for (auto It = PhysicsListeners.CreateIterator(); It; ++It)
 	{
-		if (UObject* Obj = Listener.GetObject())
+		UObject* Obj = It->Get();
+
+		if (!IsValid(Obj))
 		{
-			IJoltPhysicsCallbackInterface::Execute_OnPostPhysicsStep(Obj, DeltaTime);
+			It.RemoveCurrent();
+			continue;
 		}
+
+		IJoltPhysicsCallbackInterface::Execute_OnPostPhysicsStep(Obj, DeltaTime);
 	}
 }
 

--- a/Source/UnrealJolt/Private/JoltSubsystem.cpp
+++ b/Source/UnrealJolt/Private/JoltSubsystem.cpp
@@ -134,6 +134,54 @@ void UJoltSubsystem::AddPostInterpolationCallback(const TDelegate<void(float)>& 
 	PostInterpolationCallbacks.Add(callback);
 }
 
+void UJoltSubsystem::RegisterPhysicsListener(AActor* Listener)
+{
+	if (Listener->Implements<UJoltPhysicsCallbackInterface>())
+	{
+		const TScriptInterface<IJoltPhysicsCallbackInterface> Interface = Listener;
+		PhysicsListeners.AddUnique(Interface);
+	}
+	else
+	{
+		UE_LOG(JoltSubSystemLogs, Warning, TEXT("RegisterPhysicsListener: %s does not implement IJoltPhysicsCallbackInterface"), *Listener->GetName());
+	}
+}
+
+void UJoltSubsystem::UnregisterPhysicsListener(AActor* Listener)
+{
+	if (Listener->Implements<UJoltPhysicsCallbackInterface>())
+	{
+		const TScriptInterface<IJoltPhysicsCallbackInterface> Interface = Listener;
+		PhysicsListeners.Remove(Interface);
+	}
+	else
+	{
+		UE_LOG(JoltSubSystemLogs, Warning, TEXT("UnregisterPhysicsListener: %s does not implement IJoltPhysicsCallbackInterface"), *Listener->GetName());
+	}
+}
+
+void UJoltSubsystem::BroadcastPrePhysicsListeners(float DeltaTime)
+{
+	for (const TScriptInterface<IJoltPhysicsCallbackInterface>& Listener : PhysicsListeners)
+	{
+		if (UObject* Obj = Listener.GetObject())
+		{
+			IJoltPhysicsCallbackInterface::Execute_OnPrePhysicsStep(Obj, DeltaTime);
+		}
+	}
+}
+
+void UJoltSubsystem::BroadcastPostPhysicsListeners(float DeltaTime)
+{
+	for (const TScriptInterface<IJoltPhysicsCallbackInterface>& Listener : PhysicsListeners)
+	{
+		if (UObject* Obj = Listener.GetObject())
+		{
+			IJoltPhysicsCallbackInterface::Execute_OnPostPhysicsStep(Obj, DeltaTime);
+		}
+	}
+}
+
 void UJoltSubsystem::SetTimeScale(double deltaSeconds)
 {
 	ConfiguredDeltaSeconds = deltaSeconds;
@@ -188,6 +236,9 @@ void UJoltSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 		JoltSettings->bEnableMultithreading);
 
 	JoltWorker = new FJoltWorker(WorkerOptions);
+
+	JoltWorker->AddPrePhysicsCallback(TDelegate<void(float)>::CreateUObject(this, &UJoltSubsystem::BroadcastPrePhysicsListeners));
+	JoltWorker->AddPostPhysicsCallback(TDelegate<void(float)>::CreateUObject(this, &UJoltSubsystem::BroadcastPostPhysicsListeners));
 
 	bIsReady = true;
 	OnReady.Broadcast();

--- a/Source/UnrealJolt/Public/JoltPhysicsCallbackInterface.h
+++ b/Source/UnrealJolt/Public/JoltPhysicsCallbackInterface.h
@@ -1,0 +1,26 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "JoltPhysicsCallbackInterface.generated.h"
+
+UINTERFACE(BlueprintType)
+class UNREALJOLT_API UJoltPhysicsCallbackInterface : public UInterface
+{
+	GENERATED_BODY()
+};
+
+/** Implement to receive pre and post physics step callbacks from the Jolt subsystem. */
+class UNREALJOLT_API IJoltPhysicsCallbackInterface
+{
+	GENERATED_BODY()
+
+public:
+	/** Called before the physics step is simulated, on the game thread. */
+	UFUNCTION(BlueprintNativeEvent, Category = "Jolt Physics")
+	void OnPrePhysicsStep(float DeltaTime);
+
+	/** Called after the physics step is simulated, on the game thread. */
+	UFUNCTION(BlueprintNativeEvent, Category = "Jolt Physics")
+	void OnPostPhysicsStep(float DeltaTime);
+};

--- a/Source/UnrealJolt/Public/JoltSubsystem.h
+++ b/Source/UnrealJolt/Public/JoltSubsystem.h
@@ -11,6 +11,7 @@
 #include "Subsystems/WorldSubsystem.h"
 #include "JoltLayerTable.h"
 #include "JoltFilters.h"
+#include "JoltPhysicsCallbackInterface.h"
 #include "Delegates/DelegateCombinations.h"
 #include "UObject/ObjectMacros.h"
 
@@ -260,6 +261,16 @@ public:
 	/** Fired once per frame after InterpolatePhysicsFrame completes. dt = frame delta. */
 	void AddPostInterpolationCallback(const TDelegate<void(float)>& callback);
 
+	// Blueprint physics callback listeners
+	
+	/** Register an actor as a listener for pre and post physics step callbacks. Must implement IJoltPhysicsCallbackInterface. */
+	UFUNCTION(BlueprintCallable, Category = "Jolt Physics|Callbacks", meta = (DefaultToSelf = "Listener"))
+	void RegisterPhysicsListener(AActor* Listener);
+
+	/** Unregister an actor as a listener for pre and post physics step callbacks. Must implement IJoltPhysicsCallbackInterface. */
+	UFUNCTION(BlueprintCallable, Category = "Jolt Physics|Callbacks", meta = (DefaultToSelf = "Listener"))
+	void UnregisterPhysicsListener(AActor* Listener);
+	
 	/** Physics-frame interpolation alpha (0..1) computed in the most recent Tick. */
 	double GetPhysicsAlpha() const { return PhysicsAlpha_; }
 
@@ -467,6 +478,12 @@ private:
 	TMap<const JPH::BodyID*, FFrameHistory> JoltBodyTransformHistory;
 
 	TArray<TDelegate<void(float)>> PostInterpolationCallbacks;
+	
+	void BroadcastPrePhysicsListeners(float DeltaTime);
+	void BroadcastPostPhysicsListeners(float DeltaTime);
+	
+	UPROPERTY() 
+	TArray<TScriptInterface<IJoltPhysicsCallbackInterface>> PhysicsListeners;
 
 	bool bIsReady = false;
 

--- a/Source/UnrealJolt/Public/JoltSubsystem.h
+++ b/Source/UnrealJolt/Public/JoltSubsystem.h
@@ -483,7 +483,7 @@ private:
 	void BroadcastPostPhysicsListeners(float DeltaTime);
 	
 	UPROPERTY() 
-	TArray<TScriptInterface<IJoltPhysicsCallbackInterface>> PhysicsListeners;
+	TArray<TWeakObjectPtr<UObject>> PhysicsListeners;
 
 	bool bIsReady = false;
 


### PR DESCRIPTION
Introduces IJoltPhysicsCallbackInterface to receive OnPrePhysicsStep/OnPostPhysicsStep events. You can now hook into pre and post physics callbacks in blueprints. Use RegisterPhysicsListener and UnregisterPhysicsListener to register an actor, then implement the functions to use them.

<img width="1126" height="513" alt="image" src="https://github.com/user-attachments/assets/8af255ff-495a-47c2-a135-ed47197c1be9" />

This should help people sync their physics calls without having to use C++ delegates (#11) 

You may also use it in C++ actors if you prefer:
<img width="1075" height="925" alt="image" src="https://github.com/user-attachments/assets/f1dae7b5-dadf-4f29-9be9-5148af73f957" />
